### PR TITLE
Allow LPUSH function to get several arguments at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Redis command                                    | Description
 **HSET** *key* *field* *value*                   | Sets the string value of a hash field
 **LINDEX** *key* *index*                         | Returns the element at index *index* in the list stored at *key*
 **LLEN** *key*                                   | Returns the length of the list stored at *key*
-**LPUSH** *key* *value*                          | Pushs values at the head of a list
+**LPUSH** *key* *value* *[value ...]*            | Pushs values at the head of a list
 **LPOP** *key*                                   | Pops values at the head of a list
 **LREM** *key* *count* *value*                   | Removes `count` instances of `value` from the head of a list
 **LTRIM** *key* *start* *stop*                   | Removes the values of the `key` list which are outside the range `start`...`stop`

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -413,7 +413,13 @@ class RedisMock
             return $this->returnPipedInfo(null);
         }
 
-        array_unshift(self::$data[$key], $value);
+        // Get all values (less first parameters who is $key)
+        $values = func_get_args();
+        array_shift($values);
+
+        foreach ($values as $value) {
+            array_unshift(self::$data[$key], $value);
+        }
 
         return $this->returnPipedInfo(count(self::$data[$key]));
     }

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1341,6 +1341,14 @@ class RedisMock extends test
         $this->assert
             ->integer($redisMock->lrem('test', 1 , 'test1'))
                 ->isEqualTo(0);
+
+        $this->assert
+            // lpush allow to push further values at once
+            ->integer($redisMock->lpush('test', 'last', 'middle', 'first'))
+                ->isEqualTo(3)
+            ->array($redisMock->getData())
+                ->isEqualTo(array('test' => array('first', 'middle', 'last')))
+        ;
     }
 
     public function testFlushDb()


### PR DESCRIPTION
With this PR, it's possible to pass several arguments to LPUSH function, as documented on [Redis documentation](http://redis.io/commands/lpush)

> It is possible to push multiple elements using a single command call just specifying multiple arguments at the end of the command. Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element. So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.

Close #38 