### PR TITLE
Add type-hint to __call() method

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -179,7 +179,7 @@ class {{class}} extends \{{baseClass}}
         return $this->clientMock;
     }
 
-    public function __call($method, $args)
+    public function __call($method, array $args)
     {
         $methodName = strtolower($method);
 


### PR DESCRIPTION
I'm opening this PR more to start a discussion than getting it merged because I'm not convinced it's the best fix.

When the proxy extends `Snc\RedisBundle\Client\Phpredis\Client`, the `__call()` declaration is incompatible [because an `array` type-hint is defined in the parent class](https://github.com/snc/SncRedisBundle/blob/master/Client/Phpredis/Client.php#L49). In PHP 5 that results in "strict standard" notices, but since PHP 7 that has even turned into a warning: https://3v4l.org/tHldR

For the record here is the complete error message I'm seeing:

> Declaration of M6Web\Component\RedisMock\RedisMock_Snc_RedisBundle_Client_Phpredis_Client_Adapter::__call($method, $args) should be compatible with Snc\RedisBundle\Client\Phpredis\Client::__call($name, array $arguments)