### PR TITLE
fix rpoplpush, if rpop value is null, not reinsert it.

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1155,7 +1155,9 @@ class RedisMock
         $rpopValue = $this->rpop($sourceList);
 
         // LPUSH (send the value at the end of the $destinationList)
-        $this->lpush($destinationList, $rpopValue);
+        if (null !== $rpopValue){
+            $this->lpush($destinationList, $rpopValue);
+        }
 
         // return the rpop value;
         return $rpopValue;


### PR DESCRIPTION
Fix redis if `rpop` is  null in the `rpoplpush`