### PR TITLE
Update SET to take timeout or options array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Redis command                                    | Description
 **ZREMRANGEBYSCORE** *key* *min* *max*           | Removes all members in a sorted set within the given scores
 **ZREVRANGE** *key* *start* *stop* *[withscores]*| Returns the specified range of members in a sorted set, with scores ordered from high to low
 **ZREVRANGEBYSCORE** *key* *min* *max* *options* | Returns a range of members in a sorted set, by score, with scores ordered from high to low
+**ZSCORE** *key* *member*                        | Returns the score of *member* in the sorted set at *key*
 
 
 It mocks **MULTI**, **DISCARD** and **EXEC** commands but without any transaction behaviors, they just make the interface fluent and return each command results.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Redis command                                    | Description
 **TTL** *key*                                    | Gets the time to live for a key
 **TYPE** *key*                                   | Returns the string representation of the type of the value stored at key.
 **ZADD** *key* *score* *member*                  | Adds one member to a sorted set, or update its score if it already exists
+**ZINCRBY** *key* *increment* *member*           | Increments the score of *member* in the sorted set stored at *key* by *increment*
 **ZCARD** *key*                                  | Returns the sorted set cardinality (number of elements) of the sorted set stored at *key*
 **ZRANGE** *key* *start* *stop* *[withscores]*   | Returns the specified range of members in a sorted set
 **ZRANGEBYSCORE** *key* *min* *max* *options*    | Returns a range of members in a sorted set, by score

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -972,6 +972,8 @@ class RedisMock
             unset(self::$dataTtl[$this->storage][$key]);
         }
 
+        asort(self::$dataValues[$this->storage][$key]);
+
         return $this->returnPipedInfo((int) $isNew);
     }
 

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -977,6 +977,15 @@ class RedisMock
         return $this->returnPipedInfo((int) $isNew);
     }
 
+    public function zscore($key, $member)
+    {
+        if (!isset(self::$dataValues[$this->storage][$key][$member]) || $this->deleteOnTtlExpired($key)) {
+            return $this->returnPipedInfo(null);
+        }
+
+        return $this->returnPipedInfo(self::$dataValues[$this->storage][$key][$member]);
+    }
+
     public function zcard($key)
     {
         // returns 0 if key not found

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -995,6 +995,19 @@ class RedisMock
         return $this->returnPipedInfo(count(self::$dataValues[$this->storage][$key]));
     }
 
+    public function zincrby($key, $increment, $member)
+    {
+        if (!isset(self::$dataValues[$this->storage][$key][$member]) || $this->deleteOnTtlExpired($key)) {
+            $this->zadd($key, $increment, $member);
+            return $this->returnPipedInfo($increment);
+        }
+
+        $newScore = self::$dataValues[$this->storage][$key][$member] + $increment;
+        $this->zadd($key, $newScore, $member);
+
+        return $this->returnPipedInfo($newScore);
+    }
+
     public function zrank($key, $member)
     {
         if (!isset(self::$dataValues[$this->storage][$key]) || $this->deleteOnTtlExpired($key)) {

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -943,9 +943,18 @@ class RedisMock
     }
 
 
-    public function zadd($key, $score, $member) {
-        if (func_num_args() > 3) {
-            throw new UnsupportedException('In RedisMock, `zadd` command can not set more than one member at once.');
+    public function zadd($key, ...$args) {
+        if (count($args) === 1) {
+            if (count($args[0]) > 1) {
+                throw new UnsupportedException('In RedisMock, `zadd` used with an array cannot be used to set more than one element.');
+            }
+            $score = reset($args[0]);
+            $member = key($args[0]);
+        } elseif (count($args) === 2) {
+            $score = $args[0];
+            $member = $args[1];
+        } else {
+            throw new UnsupportedException('In RedisMock, `zadd` command  can either take two arguments (score and member), or one associative array with member as key and score as value');
         }
 
         $this->deleteOnTtlExpired($key);

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -380,7 +380,7 @@ class RedisMock
         foreach ($keys as $key) {
             $result[] = $this->smembers($key);
         }
-        $result = call_user_func_array('array_intersect', $result);
+        $result = array_values(array_intersect(...$result));
 
         $this->restorePipeline();
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -700,12 +700,12 @@ class RedisMock extends test
     public function testZRank()
     {
         $redisMock = new Redis();
-        $redisMock->zadd('test', 0, 'test6');
-        $redisMock->zadd('test', 1, 'test4');
-        $redisMock->zadd('test', 2, 'test3');
         $redisMock->zadd('test', 4, 'test1');
         $redisMock->zadd('test', 15, 'test2');
+        $redisMock->zadd('test', 2, 'test3');
+        $redisMock->zadd('test', 1, 'test4');
         $redisMock->zadd('test', 30, 'test5');
+        $redisMock->zadd('test', 0, 'test6');
 
 
         $this->assert->variable($redisMock->zrank('test', 'test6'))->isEqualTo(0);

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -686,6 +686,17 @@ class RedisMock extends test
                 ->isEqualTo(0);
     }
 
+    public function testZAddWithArray()
+    {
+        $redisMock = new Redis();
+        $redisMock->zadd('test', ['test1' => 1]);
+        $redisMock->zadd('test', ['test2' => 10]);
+
+        $this->assert
+            ->integer($redisMock->zcard('test'))
+            ->isEqualTo(2);
+    }
+
     public function testZRank()
     {
         $redisMock = new Redis();

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -129,6 +129,37 @@ class RedisMock extends test
             ->integer($redisMock->setnx("test-setnx-expire", "lala"))
                 ->isEqualTo(1);
 
+        //set with nx
+        $this->assert
+            ->string($redisMock->set('test-set-nx', 'value', ['nx']))
+            ->isEqualTo('OK');
+        $this->assert
+            ->integer($redisMock->set('test-set-nx', 'value', ['nx']))
+            ->isEqualTo(0);
+
+        //set with xx
+        $this->assert
+            ->integer($redisMock->set('test-set-xx', 'value', ['xx']))
+            ->isEqualTo(0);
+        $this->assert
+            ->string($redisMock->set('test-set-xx', 'value'))
+            ->isEqualTo('OK');
+        $this->assert
+            ->string($redisMock->set('test-set-xx', 'value2', ['xx']))
+            ->isEqualTo('OK');
+
+        //set with nx ex
+        $this->assert
+            ->string($redisMock->set('test-set-nx-ex', 'value', ['nx', 'ex' => 1]))
+            ->isEqualTo('OK');
+        $this->assert
+            ->integer($redisMock->set('test-set-nx-ex', 'value', ['nx', 'ex' => 1]))
+            ->isEqualTo(0);
+        sleep(2);
+        $this->assert
+            ->boolean($redisMock->exists('test-set-nx-ex'))
+            ->isFalse();
+
         //mget/mset test (roughly based on hmset/hmset tests)
         $this->assert
             ->array($redisMock->mget(array('raoul', 'test1')))

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -728,6 +728,25 @@ class RedisMock extends test
             ->isEqualTo(2);
     }
 
+    public function testZIncrBy()
+    {
+        $redisMock = new Redis();
+        $redisMock->zadd('test', 1, 'test1');
+        $redisMock->zadd('test', 2, 'test2');
+
+        $this->assert
+            ->integer($redisMock->zincrby('test', 10, 'test1'))
+            ->isEqualTo(11);
+
+        $this->assert
+            ->integer($redisMock->zincrby('test', -10, 'test2'))
+            ->isEqualTo(-8);
+
+        $this->assert
+            ->integer($redisMock->zincrby('test', 10, 'test16'))
+            ->isEqualTo(10);
+    }
+
     public function testZRank()
     {
         $redisMock = new Redis();

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -157,8 +157,8 @@ class RedisMock extends test
             ->isEqualTo(0);
         sleep(2);
         $this->assert
-            ->boolean($redisMock->exists('test-set-nx-ex'))
-            ->isFalse();
+            ->integer($redisMock->exists('test-set-nx-ex'))
+            ->isEqualTo(0);
 
         //mget/mset test (roughly based on hmset/hmset tests)
         $this->assert

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -482,6 +482,18 @@ class RedisMock extends test
             ->isEqualTo(['b', 'd']);
     }
 
+    public function testSInter()
+    {
+        $redisMock = new Redis();
+        $redisMock->sadd('key1', 'a', 'b', 'c', 'd');
+        $redisMock->sadd('key2', 'c');
+        $redisMock->sadd('key3', 'a', 'c', 'e');
+
+        $this->assert
+            ->array($redisMock->sinter('key1', 'key2', 'key3'))
+            ->isEqualTo(['c']);
+    }
+
     public function testSAddSMembersSIsMemberSRem()
     {
         $redisMock = new Redis();

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -679,6 +679,25 @@ class RedisMock extends test
                 ->isEqualTo(0);
     }
 
+    public function testZScore()
+    {
+        $redisMock = new Redis();
+        $redisMock->zadd('test', 1, 'test4');
+        $redisMock->zadd('test', 15, 'test2');
+
+        $this->assert
+            ->integer($redisMock->zscore('test', 'test4'))
+            ->isEqualTo(1);
+
+        $this->assert
+            ->integer($redisMock->zscore('test', 'test2'))
+            ->isEqualTo(15);
+
+        $this->assert
+            ->variable($redisMock->zscore('test', 'test99'))
+            ->isEqualTo(null);
+    }
+
     public function testZCard()
     {
         $redisMock = new Redis();


### PR DESCRIPTION
Per phpredis documentation:
_Timeout or Options Array_ (optional). If you pass an integer, phpredis will redirect to SETEX, and will try to use Redis >= 2.6.12 extended options if you pass an array with valid values

https://github.com/phpredis/phpredis/#set