### PR TITLE
Fix scan pattern

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1156,7 +1156,7 @@ class RedisMock
         // Matched values.
         $values = [];
         // Pattern, for find matched values.
-        $pattern =  str_replace('*', '.*', sprintf('/^%s/', $match));
+        $pattern =  str_replace('*', '.*', sprintf('/^%s$/', $match));
 
         for($i = $cursor; $i <= $maximumValue; $i++)
         {


### PR DESCRIPTION
**when rule has:** 
`test:1:one`
`test:2:one`
`test:1:two`
**scan pattern is:**
`test:*:one`

**correct result should:**
`test:1:one`
`test:2:one`

**but result is:**
`test:1:one`
`test:2:one`
`test:1:two `