### PR TITLE
evalsha() and eval() returning true instead of null

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1207,7 +1207,7 @@ class RedisMock
      */
     public function evalsha($script, $numkeys, ...$arguments)
     {
-        return;
+        return true;
     }
 
     /**
@@ -1220,6 +1220,6 @@ class RedisMock
      */
     public function eval($script, $numberOfKeys, ...$arguments)
     {
-        return;
+        return true;
     }
 }


### PR DESCRIPTION
For my case I needed these functions to return a non-null value.  Feel free to reject this pull request if this is not an acceptable application, but I am guessing the previous pull request just simply needed the function to exist.