### PR TITLE
Add SDIFF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Redis command                                    | Description
 **SETEX** *key* *seconds* *value*                | Sets the value and expiration of a key
 **SETNX** *key* *value*                          | Sets key to hold value if key does not exist
 **SADD** *key* *member* *[member ...]*           | Adds one or more members to a set
+**SDIFF** *key* *key* *[key ...]*                | Returns the members of the set resulting from the difference between the first set and all the successive sets.
 **SISMEMBER** *key* *member*                     | Determines if a member is in a set
 **SMEMBERS** *key*                               | Gets all the members in a set
 **SUNION** *key* *[key ...]*                     | Returns the members of the set resulting from the union of all the given sets.

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -333,6 +333,21 @@ class RedisMock
 
     }
 
+    public function sdiff($key)
+    {
+        $this->stopPipeline();
+        $keys = is_array($key) ? $key : func_get_args();
+        $result = [];
+        foreach ($keys as $key) {
+            $result[] = $this->smembers($key);
+        }
+        $result = call_user_func_array('array_diff', $result);
+
+        $this->restorePipeline();
+
+        return $this->returnPipedInfo($result);
+    }
+
     public function smembers($key)
     {
         if (!isset(self::$dataValues[$this->storage][$key]) || $this->deleteOnTtlExpired($key)) {

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -341,7 +341,7 @@ class RedisMock
         foreach ($keys as $key) {
             $result[] = $this->smembers($key);
         }
-        $result = array_values(call_user_func_array('array_diff', $result));
+        $result = array_values(array_diff(...$result));
 
         $this->restorePipeline();
 

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -341,7 +341,7 @@ class RedisMock
         foreach ($keys as $key) {
             $result[] = $this->smembers($key);
         }
-        $result = call_user_func_array('array_diff', $result);
+        $result = array_values(call_user_func_array('array_diff', $result));
 
         $this->restorePipeline();
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -479,7 +479,7 @@ class RedisMock extends test
 
         $this->assert
             ->array($redisMock->sdiff('key1', 'key2', 'key3'))
-            ->isEqualTo([1 => 'b', 3 => 'd']);
+            ->isEqualTo(['b', 'd']);
     }
 
     public function testSAddSMembersSIsMemberSRem()

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -470,6 +470,18 @@ class RedisMock extends test
                 ->isEqualTo(0);
     }
 
+    public function testSDiff()
+    {
+        $redisMock = new Redis();
+        $redisMock->sadd('key1', 'a', 'b', 'c', 'd');
+        $redisMock->sadd('key2', 'c');
+        $redisMock->sadd('key3', 'a', 'c', 'e');
+
+        $this->assert
+            ->array($redisMock->sdiff('key1', 'key2', 'key3'))
+            ->isEqualTo([1 => 'b', 3 => 'd']);
+    }
+
     public function testSAddSMembersSIsMemberSRem()
     {
         $redisMock = new Redis();


### PR DESCRIPTION
> [SDIFF](https://redis.io/commands/sdiff) Returns the members of the set resulting from the difference between the first set and all the successive sets.
> 
> ```
> key1 = {a,b,c,d}
> key2 = {c}
> key3 = {a,c,e}
> SDIFF key1 key2 key3 = {b,d}
> ```

Test:

```php
$redisMock->sadd('key1', 'a', 'b', 'c', 'd');
$redisMock->sadd('key2', 'c');
$redisMock->sadd('key3', 'a', 'c', 'e');

$this->assert
    ->array($redisMock->sdiff('key1', 'key2', 'key3'))
    ->isEqualTo(['b', 'd']);
```