### PR TITLE
Test SINTER and refactor

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -380,7 +380,7 @@ class RedisMock
         foreach ($keys as $key) {
             $result[] = $this->smembers($key);
         }
-        $result = call_user_func_array('array_intersect', $result);
+        $result = array_values(array_intersect(...$result));
 
         $this->restorePipeline();
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -482,6 +482,18 @@ class RedisMock extends test
             ->isEqualTo(['b', 'd']);
     }
 
+    public function testSInter()
+    {
+        $redisMock = new Redis();
+        $redisMock->sadd('key1', 'a', 'b', 'c', 'd');
+        $redisMock->sadd('key2', 'c');
+        $redisMock->sadd('key3', 'a', 'c', 'e');
+
+        $this->assert
+            ->array($redisMock->sinter('key1', 'key2', 'key3'))
+            ->isEqualTo(['c']);
+    }
+
     public function testSAddSMembersSIsMemberSRem()
     {
         $redisMock = new Redis();


### PR DESCRIPTION
Refactors [`SINTER`](https://redis.io/commands/sinter) like `SDIFF` #78 and add test.

> ```
> key1 = {a,b,c,d}
> key2 = {c}
> key3 = {a,c,e}
> SINTER key1 key2 key3 = {c}
> ```

Test

```php
$redisMock = new Redis();
$redisMock->sadd('key1', 'a', 'b', 'c', 'd');
$redisMock->sadd('key2', 'c');
$redisMock->sadd('key3', 'a', 'c', 'e');
$this->assert
    ->array($redisMock->sinter('key1', 'key2', 'key3'))
    ->isEqualTo(['c']);
```