### PR TITLE
Redis zadd scores are not always integer

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -988,10 +988,14 @@ class RedisMock
 
         $isNew = !isset(self::$dataValues[$this->storage][$key][$member]);
 
-        self::$dataValues[$this->storage][$key][$member] = (int) $score;
-        self::$dataTypes[$this->storage][$key]     = 'zset';
-        if (array_key_exists($key, self::$dataTtl[$this->storage]))
-        {
+        if (!is_numeric($score)) {
+            throw new \InvalidArgumentException('Score should be either an integer or a float.');
+        }
+        $score += 0; // convert potential string value to int or float
+
+        self::$dataValues[$this->storage][$key][$member] = $score;
+        self::$dataTypes[$this->storage][$key] = 'zset';
+        if (array_key_exists($key, self::$dataTtl[$this->storage])) {
             unset(self::$dataTtl[$this->storage][$key]);
         }
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -753,10 +753,22 @@ class RedisMock extends test
         $redisMock = new Redis();
         $redisMock->zadd('test', ['test1' => 1]);
         $redisMock->zadd('test', ['test2' => 10]);
+        $redisMock->zadd('test', ['test3' => 1.5]);
+        $redisMock->zadd('test', ['test4' => '10.5']);
 
         $this->assert
             ->integer($redisMock->zcard('test'))
-            ->isEqualTo(2);
+            ->isEqualTo(4);
+    }
+
+    public function testZAddDoNotAcceptNonNumericValue()
+    {
+        $redisMock = new Redis();
+        $this->exception(
+            function () use ($redisMock) {
+                $redisMock->zadd('test', ['test1' => 'NotANumeric']);
+            }
+        )->isInstanceOf(\InvalidArgumentException::class);
     }
 
     public function testZIncrBy()


### PR DESCRIPTION
From redis documentation

> Redis sorted sets use a double 64-bit floating point number to represent the score.

Not sure if this is a BC break since the library used to allow anything an automatically cast it.