### PR TITLE
Zset methods returns score as string

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -910,7 +910,7 @@ class RedisMock
         if ($min == '-inf' && $max == '+inf') {
             $slice = array_slice(self::$dataValues[$this->storage][$key], $options['limit'][0], $options['limit'][1], true);
             if (isset($options['withscores']) && $options['withscores']) {
-                return $this->returnPipedInfo($slice);
+                return $this->returnPipedInfo(array_map('strval', $slice));
             } else {
                 return $this->returnPipedInfo(array_keys($slice));
             }
@@ -947,13 +947,11 @@ class RedisMock
 
         $slice = array_slice($results, $options['limit'][0], $options['limit'][1], true);
         if (isset($options['withscores']) && $options['withscores']) {
-            return $this->returnPipedInfo($slice);
+            return $this->returnPipedInfo(array_map('strval', $slice));
         } else {
             return $this->returnPipedInfo(array_keys($slice));
         }
     }
-
-
 
     public function zrangebyscore($key, $min, $max, array $options = array())
     {
@@ -964,7 +962,6 @@ class RedisMock
     {
         return $this->zrangebyscoreHelper($key, $min, $max, $options, true);
     }
-
 
     public function zadd($key, ...$args) {
         if (count($args) === 1) {
@@ -1006,7 +1003,7 @@ class RedisMock
             return $this->returnPipedInfo(null);
         }
 
-        return $this->returnPipedInfo(self::$dataValues[$this->storage][$key][$member]);
+        return $this->returnPipedInfo((string) self::$dataValues[$this->storage][$key][$member]);
     }
 
     public function zcard($key)

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -717,11 +717,11 @@ class RedisMock extends test
         $redisMock->zadd('test', 15, 'test2');
 
         $this->assert
-            ->integer($redisMock->zscore('test', 'test4'))
+            ->string($redisMock->zscore('test', 'test4'))
             ->isEqualTo(1);
 
         $this->assert
-            ->integer($redisMock->zscore('test', 'test2'))
+            ->string($redisMock->zscore('test', 'test2'))
             ->isEqualTo(15);
 
         $this->assert
@@ -948,10 +948,10 @@ class RedisMock extends test
                     'test6',
                 ))
             ->array($redisMock->zrevrange('test', 1, -3, true))
-                ->isEqualTo(array(
-                    'test2' => 15,
-                    'test3' => 2,
-                    'test4' => 1,
+                ->isIdenticalTo(array(
+                    'test2' => '15',
+                    'test3' => '2',
+                    'test4' => '1',
                 ))
             ->integer($redisMock->del('test'))
                 ->isEqualTo(6)
@@ -1046,10 +1046,10 @@ class RedisMock extends test
                     'test3',
                 ))
             ->array($redisMock->zrangebyscore('test', '-inf', '15', array('limit' => array(1, 3), 'withscores' => true)))
-                ->isEqualTo(array(
-                    'test1' => 1,
-                    'test4' => 1,
-                    'test3' => 2,
+                ->isIdenticalTo(array(
+                    'test1' => '1',
+                    'test4' => '1',
+                    'test3' => '2',
                 ))
             ->integer($redisMock->del('test'))
                 ->isEqualTo(6)
@@ -1143,10 +1143,10 @@ class RedisMock extends test
                     'test1',
                 ))
             ->array($redisMock->zrevrangebyscore('test', '15', '-inf', array('limit' => array(1, 3), 'withscores' => true)))
-                ->isEqualTo(array(
-                    'test3' => 2,
-                    'test4' => 1,
-                    'test1' => 1,
+                ->isIdenticalTo(array(
+                    'test3' => '2',
+                    'test4' => '1',
+                    'test1' => '1',
                 ))
             ->integer($redisMock->del('test'))
                 ->isEqualTo(6)
@@ -1159,7 +1159,7 @@ class RedisMock extends test
         sleep(2);
         $this->assert
             ->array($redisMock->zrevrangebyscore('test', '1', '0'))
-                ->isEmpty();;
+                ->isEmpty();
     }
 
     public function testHSetHMSetHGetHDelHExistsHKeysHLenHGetAll()


### PR DESCRIPTION
zscore and zrange (with scores) in redis returns scores as string. 

It can be surprising that the test pass when the score is handled as an integer in testing, and as string in production (in the context of strict typing)