### PR TITLE
Fix  Unsupported operand types: int + string

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -106,7 +106,7 @@ class RedisMock
         self::$dataTypes[$this->storage][$key] = 'string';
 
         if (!is_null($seconds)) {
-            self::$dataTtl[$this->storage][$key] = time() + $seconds;
+            self::$dataTtl[$this->storage][$key] = time() + (int) $seconds;
         }
 
         return $this->returnPipedInfo('OK');


### PR DESCRIPTION
Sending a integer value for seconds in php 8.0 is causing the following error:

```php
[message] => Unsupported operand types: int + string
    [exception] => TypeError
    [file] => /application/vendor/m6web/redis-mock/src/M6Web/Component/RedisMock/RedisMock.php
    [line] => 109
    [trace] => Array
```